### PR TITLE
fix: 리프레시 토큰 사용처 수정

### DIFF
--- a/GDG-Page/src/main/java/org/example/gdgpage/config/SecurityConfig.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/config/SecurityConfig.java
@@ -37,17 +37,8 @@ public class SecurityConfig {
     private List<String> allowedOrigins;
 
     private static final String[] PUBLIC_AUTH = {
-            "/auth/signup",
-            "/auth/login",
-            "/auth/oauth/login",
-            "/auth/reissue",
-            "/auth/logout",
+            "/auth/**",
             "/oauth2/**"
-    };
-
-    private static final String[] COOKIE_AUTH_ENDPOINTS = {
-            "/user/mypage",
-            "/user/mypage/change-password"
     };
 
     private static final String[] SWAGGER_WHITELIST = {
@@ -75,7 +66,6 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_WHITELIST).permitAll()
                         .requestMatchers(PUBLIC_AUTH).permitAll()
                         .requestMatchers("/admin/**").hasAnyRole("ORGANIZER")
-                        .requestMatchers(COOKIE_AUTH_ENDPOINTS).authenticated()
                         .anyRequest().authenticated()
                 )
                 .headers(h -> h.frameOptions(Customizer.withDefaults()).disable())

--- a/GDG-Page/src/main/java/org/example/gdgpage/controller/user/UserController.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/controller/user/UserController.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.gdgpage.common.Constants;
+import org.example.gdgpage.domain.auth.AuthUser;
 import org.example.gdgpage.dto.user.request.UpdatePasswordRequest;
 import org.example.gdgpage.dto.user.response.UserResponse;
 import org.example.gdgpage.service.user.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,39 +29,37 @@ public class UserController {
     @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 프로필을 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "400", description = "리프레시 토큰이 없거나 유효하지 않음"),
             @ApiResponse(responseCode = "401", description = "인증 필요")
     })
     @GetMapping("/mypage")
-    public ResponseEntity<UserResponse> getMyProfile(@CookieValue(name = Constants.REFRESH_TOKEN, required = false) String refreshToken) {
-        UserResponse response = userService.getMyProfile(refreshToken);
+    public ResponseEntity<UserResponse> getMyProfile(@AuthenticationPrincipal AuthUser authUser) {
+        UserResponse response = userService.getMyProfile(authUser.id());
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "비밀번호 변경", description = "현재 비밀번호 검증 후 새 비밀번호로 변경")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
-            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음 또는 리프레시 토큰 유효하지 않음"),
+            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
             @ApiResponse(responseCode = "401", description = "인증 필요")
     })
     @PatchMapping("/mypage/change-password")
-    public ResponseEntity<Void> changePassword(@CookieValue(name = Constants.REFRESH_TOKEN, required = false) String refreshToken,
+    public ResponseEntity<Void> changePassword(@AuthenticationPrincipal AuthUser authUser,
                                                @Valid @RequestBody UpdatePasswordRequest request) {
-        userService.changePassword(refreshToken, request);
+        userService.changePassword(authUser.id(), request);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "프로필 이미지 변경", description = "마이페이지에서 프로필 이미지를 업로드하여 변경")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
-            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음 또는 리프레시 토큰 유효하지 않음"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "400", description = "요청 값이 유효하지 않음"),
+            @ApiResponse(responseCode = "401", description = "인증 필요")
     })
     @PatchMapping(value = "/mypage/profile-image", consumes = "multipart/form-data")
-    public ResponseEntity<UserResponse> updateProfileImage(@CookieValue(name = Constants.REFRESH_TOKEN, required = false) String refreshToken,
-                                                           @RequestPart("file") MultipartFile file
-    ) {
-        UserResponse response = userService.updateProfileImage(refreshToken, file);
+    public ResponseEntity<UserResponse> updateProfileImage(@AuthenticationPrincipal AuthUser authUser,
+                                                           @RequestPart("file") MultipartFile file) {
+        UserResponse response = userService.updateProfileImage(authUser.id(), file);
         return ResponseEntity.ok(response);
     }
 }

--- a/GDG-Page/src/main/java/org/example/gdgpage/domain/auth/AuthUser.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/domain/auth/AuthUser.java
@@ -1,0 +1,6 @@
+package org.example.gdgpage.domain.auth;
+
+public record AuthUser(
+        Long id,
+        String role
+) {}

--- a/GDG-Page/src/main/java/org/example/gdgpage/service/user/UserService.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/service/user/UserService.java
@@ -9,7 +9,6 @@ import org.example.gdgpage.exception.ErrorMessage;
 import org.example.gdgpage.exception.NotFoundException;
 import org.example.gdgpage.mapper.UserMapper;
 import org.example.gdgpage.repository.UserRepository;
-import org.example.gdgpage.service.finder.FindUser;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,53 +20,45 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final FindUser findUser;
     private final ProfileImageStorage profileImageStorage;
 
     @Transactional(readOnly = true)
-    public UserResponse getMyProfile(String refreshToken) {
-        User user = getUserFromRefreshToken(refreshToken);
-
+    public UserResponse getMyProfile(Long userId) {
+        User user = getUser(userId);
         return UserMapper.toUserResponse(user);
     }
 
     @Transactional
-    public void changePassword(String refreshToken, UpdatePasswordRequest updatePasswordRequest) {
-        User user = getUserFromRefreshToken(refreshToken);
+    public void changePassword(Long userId, UpdatePasswordRequest request) {
+        User user = getUser(userId);
 
         if (user.getPassword() == null) {
             throw new BadRequestException(ErrorMessage.OAUTH_ACCOUNT_CANNOT_CHANGE_PASSWORD);
         }
 
-        if (!passwordEncoder.matches(updatePasswordRequest.currentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
             throw new BadRequestException(ErrorMessage.WRONG_CURRENT_PASSWORD);
         }
 
-        if (!updatePasswordRequest.newPassword().equals(updatePasswordRequest.confirmNewPassword())) {
+        if (!request.newPassword().equals(request.confirmNewPassword())) {
             throw new BadRequestException(ErrorMessage.WRONG_CHECK_PASSWORD);
         }
 
-        String encoded = passwordEncoder.encode(updatePasswordRequest.newPassword());
-        user.updatePassword(encoded);
-    }
-
-    private User getUserFromRefreshToken(String refreshToken) {
-        Long userId = findUser.getUserIdFromRefreshToken(refreshToken);
-
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_EXIST_USER));
+        user.updatePassword(passwordEncoder.encode(request.newPassword()));
     }
 
     @Transactional
-    public UserResponse updateProfileImage(String refreshToken, MultipartFile file) {
-        Long userId = findUser.getUserIdFromRefreshToken(refreshToken);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_EXIST_USER));
+    public UserResponse updateProfileImage(Long userId, MultipartFile file) {
+        User user = getUser(userId);
 
         String imageUrl = profileImageStorage.storeProfileImage(userId, file);
         user.updateProfileImage(imageUrl);
 
         return UserMapper.toUserResponse(user);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_EXIST_USER));
     }
 }


### PR DESCRIPTION
- 리프레시 토큰은 토큰 재발급과 로그아웃 기능에서만 사용하도록 함
- 그 외 사용자 인증이 필요한 서비스는 액세스 토큰으로 인증