### PR TITLE
feat: 자유게시판 글/댓글 프로필 이미지 반환 추가

### DIFF
--- a/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreeCommentResponseDto.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreeCommentResponseDto.java
@@ -1,6 +1,7 @@
 package org.example.gdgpage.dto.freeboard.response;
 
 import lombok.Getter;
+import org.example.gdgpage.common.Constants;
 import org.example.gdgpage.domain.freeboard.FreeComment;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ public class FreeCommentResponseDto {
     private final String content;
     private final Boolean isAnonymous;
     private final String authorName;
+    private final String profileImageUrl;
     private final Integer likeCount;
     private final Long parentId;
     private final LocalDateTime createdAt;
@@ -28,6 +30,10 @@ public class FreeCommentResponseDto {
         this.authorName = comment.getIsAnonymous()
                 ? "익명"
                 : comment.getAuthor().getName();
+
+        this.profileImageUrl = isAnonymous
+                ? Constants.DEFAULT_PROFILE_IMAGE_URL
+                : comment.getAuthor().getProfileImageUrl();
 
         this.likeCount = comment.getLikeCount();
         this.parentId = comment.getParent() != null

--- a/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreePostListResponseDto.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreePostListResponseDto.java
@@ -1,6 +1,7 @@
 package org.example.gdgpage.dto.freeboard.response;
 
 import lombok.Getter;
+import org.example.gdgpage.common.Constants;
 import org.example.gdgpage.domain.freeboard.FreePost;
 
 import java.time.LocalDateTime;
@@ -17,7 +18,9 @@ public class FreePostListResponseDto {
     private final Integer viewCount;
     private final Integer likeCount;
     private final Integer commentCount;
+    private final String profileImageUrl;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
     public FreePostListResponseDto(FreePost post) {
 
@@ -27,14 +30,19 @@ public class FreePostListResponseDto {
                 ? "익명"
                 : post.getAuthor().getName();
 
-        this.previewContent = createPreview(post.getContent());
-
         this.isAnonymous = post.getIsAnonymous();
+
+        this.profileImageUrl = isAnonymous
+                ? Constants.DEFAULT_PROFILE_IMAGE_URL
+                : post.getAuthor().getProfileImageUrl();
+
+        this.previewContent = createPreview(post.getContent());
         this.isPinned = post.getIsPinned();
         this.viewCount = post.getViewCount();
         this.likeCount = post.getLikeCount();
         this.commentCount = post.getCommentCount();
         this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
     }
 
     private String createPreview(String content) {

--- a/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreePostResponseDto.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/dto/freeboard/response/FreePostResponseDto.java
@@ -1,6 +1,7 @@
 package org.example.gdgpage.dto.freeboard.response;
 
 import lombok.Getter;
+import org.example.gdgpage.common.Constants;
 import org.example.gdgpage.domain.freeboard.FreePost;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ public class FreePostResponseDto {
     private final Integer likeCount;
     private final Integer commentCount;
     private final String authorName;
+    private final String profileImageUrl;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
@@ -29,6 +31,10 @@ public class FreePostResponseDto {
         this.authorName = post.getIsAnonymous()
                 ? "익명"
                 : post.getAuthor().getName();
+
+        this.profileImageUrl = isAnonymous
+                ? Constants.DEFAULT_PROFILE_IMAGE_URL
+                : post.getAuthor().getProfileImageUrl();
 
         this.isPinned = post.getIsPinned();
         this.viewCount = post.getViewCount();


### PR DESCRIPTION
## 작업 내용
- 자유게시판 글 / 댓글 조회 시 프로필 이미지 반환 기능 추가
- 익명 글/댓글일 경우 → DEFAULT_PROFILE_IMAGE_URL 반환
- 비익명일 경우 → 작성자의 profileImageUrl 반환
- FreePostListResponseDto에 updatedAt 필드 추가

추가된 API는 없습니다.