### PR TITLE
feat: 자유게시판 검색 기능 구현

### DIFF
--- a/GDG-Page/src/main/java/org/example/gdgpage/controller/freeboard/FreePostController.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/controller/freeboard/FreePostController.java
@@ -59,9 +59,8 @@ public class FreePostController {
 
 
     @GetMapping("/{postId}")
-    public ResponseEntity<FreePostResponseDto> getPost(@AuthenticationPrincipal AuthUser authUser,
-                                                       @PathVariable Long postId) {
-        FreePostResponseDto response = freePostService.getPost(postId, authUser.id());
+    public ResponseEntity<FreePostResponseDto> getPost(@PathVariable Long postId) {
+        FreePostResponseDto response = freePostService.getPost(postId);
         return ResponseEntity.ok(response);
     }
 

--- a/GDG-Page/src/main/java/org/example/gdgpage/repository/freeboard/FreePostRepository.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/repository/freeboard/FreePostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FreePostRepository extends JpaRepository<FreePost, Long> {
 
@@ -18,4 +19,11 @@ public interface FreePostRepository extends JpaRepository<FreePost, Long> {
         order by p.isPinned desc, p.createdAt desc
     """)
     List<FreePost> findAllWithAuthorAndKeyword(@Param("keyword") String keyword);
+
+    @Query("""
+        select p from FreePost p
+        join fetch p.author
+        where p.id = :postId
+    """)
+    Optional<FreePost> findWithAuthor(@Param("postId") Long postId);
 }

--- a/GDG-Page/src/main/java/org/example/gdgpage/service/freeboard/FreePostService.java
+++ b/GDG-Page/src/main/java/org/example/gdgpage/service/freeboard/FreePostService.java
@@ -103,9 +103,9 @@ public class FreePostService {
     }
 
     @Transactional
-    public FreePostResponseDto getPost(Long postId, Long userId) {
+    public FreePostResponseDto getPost(Long postId) {
 
-        FreePost post = freePostRepository.findById(postId)
+        FreePost post = freePostRepository.findWithAuthor(postId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_EXIST_POST));
 
         post.increaseViewCount();


### PR DESCRIPTION
## 작업 내용
- 자유게시판 제목으로 검색 기능 구현
- `keyword`가 공백 또는 null일 경우 → 전체 게시글 반환

## 예시
- `/api/free-posts` → 전체 게시글 정상 반환
- `/api/free-posts?keyword=dd` → 해당 검색어를 포함한 게시글만 반환
- `/api/free-posts?keyword=` → 전체 게시글 반환

<img width="1284" height="1482" alt="CleanShot 2025-12-24 at 21 38 00@2x" src="https://github.com/user-attachments/assets/74e11856-51c4-4252-91ad-9ad24cde0236" />
<img width="1298" height="1422" alt="CleanShot 2025-12-24 at 21 56 50@2x" src="https://github.com/user-attachments/assets/e8943b9e-20c6-4a36-a876-36cfe5afc856" />

